### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/completions/mix.fish
+++ b/completions/mix.fish
@@ -10,7 +10,7 @@ end
 
 # fish completion for mix
 function __fish_mix_tasks
-    mix help ^/dev/null | awk '{
+    mix help 2>/dev/null | awk '{
         if ($1 == "mix") {
             if ($3 == "#") {
                 print $2"\t"substr($0, index($0, $4))


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
